### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ platform :ios do
   desc "Build and distribute build to Crashlytics"
   lane :beta do
     gym(scheme: "Release")
-    crashlytics(crashlytics_path: "./Crashlytics.framework/submit")
+    crashlytics(crashlytics_path: "./Crashlytics.framework/")
   end
 end
 ```


### PR DESCRIPTION
In the latest version, you need to actually specify the crashlytics path, and not path to the submit binary.

When using the old docs directly, the crashlytics module crashes with the following error:
Could not find submit binary in crashlytics bundle at path './Crashlytics.framework/submit'

This is due to line 7 of crashlytics_helper.rb, where it uses File.join on the parameter, and joins the path with "**" and "submit", which results in the script trying to locate the "submit" binary in "Crashlytics.framework/submit/**/".