### PR TITLE
Made example crashlytics call more useful

### DIFF
--- a/samples-ios/distribute-beta-build.md
+++ b/samples-ios/distribute-beta-build.md
@@ -30,12 +30,7 @@ platform :ios do
       api_token: "...",
       build_secret: "...",
       groups: "qa-team",
-      notes_path: "./release-notes.txt"
-      # ipa_path: "..." Path to your IPA file. Optional if you use the `gym` or `xcodebuild` action.
-      # crashlytics_path: "..." Path to the submit binary in the Crashlytics bundle (default: './Crashlytics.framework')
-      # emails: "..." Pass email addresses of testers, separated by commas
-      # notifications: "..." Crashlytics notification option (true/false) (default: 'true')
-      # debug: "..." Crashlytics debug option (true/false)
+      notes: "Automatic iOS Build"
     )
   end
 end


### PR DESCRIPTION
We tell the user about more parameters right below the example (`fastlane action crashlytics`)
Also, `notes_path` is pretty annoying for a user, instead we can just use `notes`