### PR TITLE
Update Crashlytics path for Cocoapods

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ platform :ios do
     gym(scheme: "Release")
 
     # Distribute via Crashlytics
-    crashlytics(crashlytics_path: "./Crashlytics.framework/submit",
+    crashlytics(crashlytics_path: "./Crashlytics.framework/submit", # "./Pods/Crashlytics" if using Cocoapods
                 notes: changelog)
 
     # Post Slack notification


### PR DESCRIPTION
Added caveat to Crashlytics path when using Cocoapods